### PR TITLE
Fix issue when using dark mode as system theme.

### DIFF
--- a/switch.js
+++ b/switch.js
@@ -5,59 +5,96 @@
 
 (function () {
   let lightSwitch = document.getElementById("lightSwitch");
-  if (lightSwitch) {
-    darkMode();
-    lightSwitch.addEventListener("change", () => {
-      lightMode();
+  if (!lightSwitch) {
+    return;
+  }
+  
+  /**
+   * @function darkmode
+   * @summary: changes the theme to 'dark mode' and save settings to local stroage.
+   * Basically, replaces/toggles every CSS class that has '-light' class with '-dark'
+   */
+  function darkMode() {
+    document.querySelectorAll(".bg-light").forEach((element) => {
+      element.className = element.className.replace(/-light/g, "-dark");
     });
 
-    /**
-     * @function darkmode
-     * @summary: firstly, checks if browser local storage has 'lightSwitch' key
-     * if key has 'dark' value then changes the theme to 'dark mode'
-     * Basically, replaces/toggles every CSS class that has '-light' class with '-dark'
-     */
-    function darkMode() {
-      let isSelected =
-        localStorage.getItem("lightSwitch") !== null &&
-        localStorage.getItem("lightSwitch") === "dark";
+    document.body.classList.add("bg-dark");
 
-      if (isSelected) {
-        document.querySelectorAll(".bg-light").forEach((element) => {
-          element.className = element.className.replace(/-light/g, "-dark");
-        });
-
-        document.body.classList.add("bg-dark");
-
-        if (document.body.classList.contains("text-dark")) {
-          document.body.classList.replace("text-dark", "text-light");
-        } else {
-          document.body.classList.add("text-light");
-        }
-        
-        // set light switch input to true
-        lightSwitch.checked = true;
-      }
+    if (document.body.classList.contains("text-dark")) {
+      document.body.classList.replace("text-dark", "text-light");
+    } else {
+      document.body.classList.add("text-light");
     }
+    
+    // set light switch input to true
+    if (! lightSwitch.checked) {
+      lightSwitch.checked = true;
+    }
+    localStorage.setItem("lightSwitch", "dark");
+  }
 
-    /**
-     * @function lightmode
-     * @summary: check whether the switch is on (checked) or not.
-     * If the switch is on then set 'lightSwitch' local storage key and call @function darkmode
-     * If the switch is off then it is light mode so, switch the theme and
-     *  remove 'lightSwitch' key from local storage
-     */
-    function lightMode() {
-      if (lightSwitch.checked) {
-        localStorage.setItem("lightSwitch", "dark");
-        darkMode();
-      } else {
-        document.querySelectorAll(".bg-dark").forEach((element) => {
-          element.className = element.className.replace(/-dark/g, "-light");
-        });
-        document.body.classList.replace("text-light", "text-dark");
-        localStorage.removeItem("lightSwitch");
-      }
+  /**
+   * @function lightmode
+   * @summary: changes the theme to 'light mode' and save settings to local stroage.
+   */
+  function lightMode() {
+    document.querySelectorAll(".bg-dark").forEach((element) => {
+      element.className = element.className.replace(/-dark/g, "-light");
+    });
+
+    document.body.classList.add("bg-light");
+
+    if (document.body.classList.contains("text-light")) {
+      document.body.classList.replace("text-light", "text-dark");
+    } else {
+      document.body.classList.add("text-dark");
+    }
+    
+    if (lightSwitch.checked) {
+      lightSwitch.checked = false;
+    }
+    localStorage.setItem("lightSwitch", "light");
+  }
+  
+  /**
+   * @function onToggleMode
+   * @summary: the event handler attached to the switch. calling @darkMode or @lightMode depending on the checked state.
+   */
+  function onToggleMode() {
+    if (lightSwitch.checked) {
+      darkMode();
+    } else {
+      lightMode();
     }
   }
+  
+  /**
+   * @function getSystemDefaultTheme
+   * @summary: get system default theme by media query
+   */
+  function getSystemDefaultTheme() {
+    const darkThemeMq = window.matchMedia("(prefers-color-scheme: dark)");
+    if (darkThemeMq.matches) {
+      return "dark";
+    }
+    return "light";
+  }
+
+  function setup() {
+    var settings = localStorage.getItem("lightSwitch");
+    if (settings == null) {
+      settings = getSystemDefaultTheme();
+    }
+    
+    if (settings == "dark") {
+      lightSwitch.checked = true;
+    }
+    
+    lightSwitch.addEventListener("change", onToggleMode);
+    onToggleMode();
+  }
+  
+  setup();
+  
 })();


### PR DESCRIPTION
I'm using dark mode system widely, basically the body without any bg-dark/light class, it shows up this white background page. When I just toggle the switch, all works fine so I'd like to put a media query to get the initial value. 

![image](https://user-images.githubusercontent.com/2174103/140700310-1ea727c4-8397-42d0-a6a0-a489bac9ae12.png)

And, just a little bit of refactoring.

Thanks for the good module. 
